### PR TITLE
Make 3rd and 4th lecture on Compilers public

### DIFF
--- a/course/compiler/compiler.html
+++ b/course/compiler/compiler.html
@@ -55,11 +55,11 @@ h3 {
 <h2>Lecture Notes</h2>
 <li class="hangingindent">Lecture 1: Introduction to Compilers (<a target="_blank" style="text-decoration:none" href="./LectureNotes/(Spring2018)Lecture1.pptx" download="Lecture1"> <img src="../../image/PPTLogo.png" width="25" height="25" alt="PPT" /></a>)</li>
 <li class="hangingindent">Lecture 2: An Overview of Formal Languages and Grammars (<a target="_blank" style="text-decoration:none" href="./LectureNotes/(Spring2018)Lecture2.pptx" download="Lecture2"> <img src="../../image/PPTLogo.png" width="25" height="25" alt="PPT" /></a>)</li>
-<!--<li class="hangingindent">Lecture 3: Lexical Analysis (<a target="_blank" style="text-decoration:none" href="./LectureNotes/(Spring2018)Lecture3.pptx" download="Lecture3"> <img src="../../image/PPTLogo.png" width="25" height="25" alt="PDF" /></a>)</li>
+<li class="hangingindent">Lecture 3: Lexical Analysis (<a target="_blank" style="text-decoration:none" href="./LectureNotes/(Spring2018)Lecture3.pptx" download="Lecture3"> <img src="../../image/PPTLogo.png" width="25" height="25" alt="PDF" /></a>)</li>
 <li class="hangingindent">Lecture 4: Top-Down Parsing (<a target="_blank" style="text-decoration:none" href="./LectureNotes/(Spring2018)Lecture4.pptx" download="Lecture4"> <img src="../../image/PPTLogo.png" width="25" height="25" alt="PDF" /></a>)</li>
-<li class="hangingindent">Lecture 5: Bottom-Up Parsing (<a target="_blank" style="text-decoration:none" href="./LectureNotes/(Spring2018)Lecture5.pptx" download="Lecture5"> <img src="../../image/PPTLogo.png" width="25" height="25" alt="PDF" /></a>)</li>
-<li class="hangingindent">Lecture 6: Syntax-Directed Translation (<a target="_blank" style="text-decoration:none" href="./LectureNotes/(Spring2018)Lecture6.pptx" download="Lecture6"> <img src="../../image/PPTLogo.png" width="25" height="25" alt="PDF" /></a>)</li>
-<li class="hangingindent">Lecture 7: Intermediate-Code Generation (<a target="_blank" style="text-decoration:none" href="./LectureNotes/(Spring2018)Lecture7.pptx" download="Lecture7"> <img src="../../image/PPTLogo.png" width="25" height="25" alt="PDF" /></a>)</li>-->
+<!-- <li class="hangingindent">Lecture 5: Bottom-Up Parsing (<a target="_blank" style="text-decoration:none" href="./LectureNotes/(Spring2018)Lecture5.pptx" download="Lecture5"> <img src="../../image/PPTLogo.png" width="25" height="25" alt="PDF" /></a>)</li> -->
+<!-- <li class="hangingindent">Lecture 6: Syntax-Directed Translation (<a target="_blank" style="text-decoration:none" href="./LectureNotes/(Spring2018)Lecture6.pptx" download="Lecture6"> <img src="../../image/PPTLogo.png" width="25" height="25" alt="PDF" /></a>)</li> -->
+<!--<li class="hangingindent">Lecture 7: Intermediate-Code Generation (<a target="_blank" style="text-decoration:none" href="./LectureNotes/(Spring2018)Lecture7.pptx" download="Lecture7"> <img src="../../image/PPTLogo.png" width="25" height="25" alt="PDF" /></a>)</li>-->
 </div>
 
 <div>


### PR DESCRIPTION
I've uncommented `<li>` from `compiler/compiler.html` to make 3rd and 4th lectures' presentations public, because some of the students do not how to access the github repo.